### PR TITLE
since child scripts have their own path...

### DIFF
--- a/cico_common.sh
+++ b/cico_common.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
+
 function die_with() 
 {
 	echo "$*" >&2

--- a/cico_release.sh
+++ b/cico_release.sh
@@ -469,9 +469,8 @@ releaseOperator() {
     wget https://github.com/operator-framework/operator-sdk/releases/download/v0.10.0/operator-sdk-v0.10.0-x86_64-linux-gnu -O $OP_SDK_DIR/operator-sdk 
     chmod +x $OP_SDK_DIR/operator-sdk
 
-    BASE32_UTIL_PATH=$(pwd)/utils
-    # add base32 shortcut
-    export PATH="$PATH:$OP_SDK_DIR:$BASE32_UTIL_PATH"
+    # copy base32 python-based helper script into dir that's accessed from PATH (so it's accessible to this and other called scripts) 
+    cp -f ${SCRIPT_DIR}/utils/base32 /usr/local/bin/ && chmod +x /usr/local/bin/base32
 
     git clone git@github.com:eclipse/che-operator.git
     cd che-operator

--- a/utils/base32
+++ b/utils/base32
@@ -1,14 +1,24 @@
 #!/bin/bash
 
-DECODE=0
+usage () {
+    echo "This is a replacement for base32 (from GNU coreutils), which is not easily available on ci-centos machines.
 
+Usage:
+  pipe content to be encoded into this executable, or pipe content with -d to decode.
+
+Examples:
+  echo 'some string that I used to know' | $0 # ONXW2ZJAON2HE2LOM4QHI2DBOQQESIDVONSWIIDUN4QGW3TPO4======
+  echo 'ONXW2ZJAON2HE2LOM4QHI2DBOQQESIDVONSWIIDUN4QGW3TPO4======' | $0 -d # some string that I used to know
+"
+    exit
+}
+
+DECODE=0
 for i in "$@"
 do
 case $i in
-    -d)
-    DECODE=1
-    shift # past argument=value
-    ;;
+    -d) DECODE=1; shift;;
+    --help|--version) usage; shift;;
 esac
 done
 


### PR DESCRIPTION
since child scripts have their own path defaults, copy base32 python script into /usr/local/bin/base32 so it's accessible by any script

Fixes:
```
/root/payload/che/che-operator/olm/addDigests.sh: line 101: base32: command not found
```

Change-Id: I180a33d2fc19a688cdb576b3fd7cfaea90ce9762
Signed-off-by: nickboldt <nboldt@redhat.com>