### PR TITLE
enable rh-git218 for all users/bash shells...

### DIFF
--- a/cico_release.sh
+++ b/cico_release.sh
@@ -43,7 +43,12 @@ installDeps(){
     sudo yum install -y centos-release-scl-rh
     subscription-manager repos --enable=rhel-server-rhscl-7-rpms || true
     sudo yum install -y rh-git218
-    scl enable rh-git218 bash || exit 1
+    # enable rh-git218 for all users/bash shells
+    echo "#!/bin/bash
+source scl_source enable rh-git218" > /etc/profile.d/enablerh-git218.sh && chmod +x /etc/profile.d/enablerh-git218.sh
+    # run the enablement script
+    /etc/profile.d/enablerh-git218.sh
+    # alias git='scl enable rh-git218 git' # another approach?
     git --version
 
     yum -y install skopeo


### PR DESCRIPTION
enable rh-git218 for all users/bash shells (per https://access.redhat.com/solutions/527703 ); if this doesn't work we can try using an alias but that might not work in subshells

Change-Id: I95d492c5230f01db59348c728b69719a42a0a332
Signed-off-by: nickboldt <nboldt@redhat.com>