### PR TITLE
Adapt make-release.sh to use the eclipse-che org registries

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -156,10 +156,10 @@ releaseCheTheia() {
 }
 
 releaseDevfileRegistry() {
-    invokeAction eclipse/che-devfile-registry "Release Che Devfile Registry" "4191260" "version=${CHE_VERSION}"
+    invokeAction eclipse-che/che-devfile-registry "Release Che Devfile Registry" "4191260" "version=${CHE_VERSION}"
 }
 releasePluginRegistry() {
-    invokeAction eclipse/che-plugin-registry "Release Che Plugin Registry" "4191251" "version=${CHE_VERSION}"
+    invokeAction eclipse-che/che-plugin-registry "Release Che Plugin Registry" "4191251" "version=${CHE_VERSION}"
 }
 
 branchJWTProxyAndKIP() {


### PR DESCRIPTION
Adapt the `make-release.sh` script to use the plugin and devfile registries from the new org.

Part of eclipse/che#19388 and eclipse/che#19387

Only to be merged after: https://bugs.eclipse.org/bugs/show_bug.cgi?id=571958#c10 is fulfilled.